### PR TITLE
Add Loki&Promtail stack

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -16,6 +16,7 @@ in
       ./modules/mqtt.nix
       ./modules/node-exporter.nix
       ./modules/nginx.nix
+      ./modules/promtail.nix
     ];
 
   };
@@ -29,6 +30,7 @@ in
       ./modules/loki.nix
       ./modules/node-exporter.nix
       ./modules/prometheus.nix
+      ./modules/promtail.nix
     ];
   };
 
@@ -38,6 +40,7 @@ in
       ./modules/common.nix
       ./modules/consul.nix
       ./modules/node-exporter.nix
+      ./modules/promtail.nix
     ];
   };
 }

--- a/home.nix
+++ b/home.nix
@@ -26,6 +26,7 @@ in
       ./modules/common.nix
       ./modules/consul.nix
       ./modules/grafana.nix
+      ./modules/loki.nix
       ./modules/node-exporter.nix
       ./modules/prometheus.nix
     ];

--- a/modules/grafana.nix
+++ b/modules/grafana.nix
@@ -18,6 +18,11 @@
           type = "prometheus";
           url = "http://prometheus.thewagner.home";
         }
+        {
+          name = "Loki";
+          type = "loki";
+          url = "http://nuc.thewagner.home:3100";
+        }
       ];
     };
   };

--- a/modules/grafana.nix
+++ b/modules/grafana.nix
@@ -7,7 +7,7 @@
     enable = true;
     addr = "0.0.0.0";
     auth.anonymous.enable = true;
-    auth.anonymous.org_role = "Viewer";
+    auth.anonymous.org_role = "Admin";
 
     provision = {
       enable = true;

--- a/modules/loki.nix
+++ b/modules/loki.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, ... }:
+
+let
+
+  httpPort = 3100;
+
+in
+
+{
+  imports = [ ./consul-catalog.nix ];
+
+  services.loki = {
+    enable = true;
+    configFile = ''
+      ${pkgs.grafana-loki.src}/cmd/loki/loki-local-config.yaml
+    '';
+  };
+
+  services.consul.catalog = [
+    {
+      name = "loki";
+      port = httpPort;
+    }
+  ];
+
+  networking.firewall.allowedTCPPorts = [ httpPort ];
+}

--- a/modules/prometheus.nix
+++ b/modules/prometheus.nix
@@ -40,6 +40,15 @@ let
       ];
     }
     {
+      job_name = "loki";
+      consul_sd_configs = [
+        {
+          server = consulAgent;
+          services = [ "loki" ];
+        }
+      ];
+    }
+    {
       job_name = "telegraf";
       consul_sd_configs = [
         {

--- a/modules/prometheus.nix
+++ b/modules/prometheus.nix
@@ -49,6 +49,15 @@ let
       ];
     }
     {
+      job_name = "promtail";
+      consul_sd_configs = [
+        {
+          server = consulAgent;
+          services = [ "promtail" ];
+        }
+      ];
+    }
+    {
       job_name = "telegraf";
       consul_sd_configs = [
         {

--- a/modules/promtail.nix
+++ b/modules/promtail.nix
@@ -1,0 +1,66 @@
+{ config, pkgs, ... }:
+
+let
+
+  httpPort = 9080;
+
+  configFile = pkgs.writeText "promtail-config.yaml" ''
+    server:
+      http_listen_port: ${toString httpPort}
+      grpc_listen_port: 0
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    clients:
+      - url: http://nuc.thewagner.home:3100/loki/api/v1/push
+
+    scrape_configs:
+    - job_name: journal
+      journal:
+        path: /var/log/journal
+        max_age: 12h
+        labels:
+          job: systemd-journal
+      relabel_configs:
+       - source_labels: ['__journal__systemd_unit' ]
+         target_label: 'unit'
+       - source_labels: ['__journal__hostname']
+         target_label: 'hostname'
+  '';
+
+in
+
+{
+  imports = [ ./consul-catalog.nix ];
+
+  systemd.services.promtail = {
+    description = "Promtail service for Loki";
+    wantedBy = [ "multi-user.target" ];
+
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.grafana-loki}/bin/promtail --config.file ${configFile}
+      '';
+      User = "promtail";
+      Group = "promtail";
+    };
+  };
+
+  users.groups.promtail = { };
+  users.users.promtail = {
+    description = "Promtail Service User";
+    group = "promtail";
+    extraGroups = [ "systemd-journal" ];
+    isSystemUser = true;
+  };
+
+  services.consul.catalog = [
+    {
+      name = "promtail";
+      port = httpPort;
+    }
+  ];
+
+  networking.firewall.allowedTCPPorts = [ httpPort ];
+}


### PR DESCRIPTION
Configure the Loki log aggregator server and use Promtail to collect the log entries from the Systemd journal:
- Configure the Loki and Promtail services
- Scrape their metrics  with Prometheus
- Add Loki as a Grafana datasource
